### PR TITLE
fix(26.2): Fixed lwjgl headless launching for 26.2

### DIFF
--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -84,6 +84,17 @@ jobs:
         if: github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/')
         run: ./gradlew build --stacktrace
 
+      - name: Upload Test Reports
+        if: failure()
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-reports
+          path: |
+            **/build/reports/tests/**
+            **/build/test-results/**
+          if-no-files-found: ignore
+
       - name: Publish with gradle
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         env:

--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -505,7 +505,7 @@ jobs:
           # to test if this step works
           - { mc: 26.2, type: fabric, modloader: fabric, regex: .*fabric.*, java: 25 }
           - { mc: 26.2, type: neoforge, modloader: neoforge, regex: .*neoforge.*, java: 25 }
-          - { mc: 26.2, type: lexforge, modloader: lexforge, regex: .*forge.*, java: 25 }
+          - { mc: 26.2, type: lexforge, modloader: forge, regex: .*forge.*, java: 25 }
     runs-on: ubuntu-latest
     if: '!cancelled()' # run always cause we want to see how each version is doing
     #if: false for when mc-runtime-test is up to date and HeadlessMc can launch any version

--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -484,7 +484,7 @@ jobs:
           # regardless if mc-runtime-test already supports this version or not
           # to test if this step works
           #- { branch: main, dir: 26_1,  mc: 26.1.1, lex: 63.0.1, neo: 3-beta, java: 25 }
-          - { branch: main, dir: 1_21_10,  mc: 1.21.10, lex: 60.0.0, neo: 50-beta, java: 21 }
+          - { branch: claude/github-issue-137-05c8df, dir: 26_2,  mc: 26.2, lex: 65.0.3, neo: 8-beta, java: 25 }
     uses: ./.github/workflows/build-runtime-test.yml
     if: '!cancelled()' # run always cause we want to see how each version is doing
     #if: false for when mc-runtime-test is up to date and HeadlessMc can launch any version
@@ -503,7 +503,9 @@ jobs:
           # the following line should always be here,
           # regardless if mc-runtime-test already supports this version or not
           # to test if this step works
-          - { mc: 1.21.10, type: fabric, modloader: fabric, regex: .*fabric.*, java: 21 }
+          - { mc: 26.2, type: fabric, modloader: fabric, regex: .*fabric.*, java: 25 }
+          - { mc: 26.2, type: neoforge, modloader: neoforge, regex: .*neoforge.*, java: 25 }
+          - { mc: 26.2, type: lexforge, modloader: lexforge, regex: .*forge.*, java: 25 }
     runs-on: ubuntu-latest
     if: '!cancelled()' # run always cause we want to see how each version is doing
     #if: false for when mc-runtime-test is up to date and HeadlessMc can launch any version

--- a/headlessmc-lwjgl/src/main/java/io/github/headlesshq/headlessmc/lwjgl/LwjglProperties.java
+++ b/headlessmc-lwjgl/src/main/java/io/github/headlesshq/headlessmc/lwjgl/LwjglProperties.java
@@ -11,7 +11,10 @@ public interface LwjglProperties {
     String BITS_PER_PIXEL = "hmc.lwjgl.bitsperpixel";
     String JNI_VERSION = "hmc.lwjgl.nativejniversion";
     String UNIFORM_OFFSET_ALIGNMENT = "hmc.lwjgl.uniformoffsetalignment";
+    String MAX_DRAW_BUFFERS = "hmc.lwjgl.maxdrawbuffers";
+    String MAX_TEXTURE_SIZE = "hmc.lwjgl.maxtexturesize";
     String NO_AWT = "hmc.lwjgl.no.awt";
+    String IGNORE_CLASSES = "hmc.lwjgl.ignore.classes";
 
     String TWEAKER_MAIN_CLASS = "hmc.tweaker.main.class";
 

--- a/headlessmc-lwjgl/src/main/java/io/github/headlesshq/headlessmc/lwjgl/redirections/LwjglConfig.java
+++ b/headlessmc-lwjgl/src/main/java/io/github/headlesshq/headlessmc/lwjgl/redirections/LwjglConfig.java
@@ -9,6 +9,8 @@ public class LwjglConfig {
     public static final int GL_TEXTURE_WIDTH = 4096;
     public static final int GL_TEXTURE_INTERNAL_FORMAT_CONST = 4099;
     public static final int GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT = 0x8A34;
+    public static final int GL_MAX_DRAW_BUFFERS = 0x8824;
+    public static final int GL_MAX_TEXTURE_SIZE = 0xD33;
 
     public static final int GL_TEXTURE_INTERNAL_FORMAT = Integer.parseInt(
         System.getProperty(LwjglProperties.GL_TEXTURE_INTERNAL_FORMAT, "32856")); //RGBA8
@@ -17,9 +19,9 @@ public class LwjglConfig {
     public static final boolean FULLSCREEN = Boolean.parseBoolean(
         System.getProperty(LwjglProperties.FULLSCREEN, "true"));
     public static final int SCREEN_WIDTH = Integer.parseInt(
-        System.getProperty(LwjglProperties.SCREEN_WIDTH, "1920"));
+        System.getProperty(LwjglProperties.SCREEN_WIDTH, "800"));
     public static final int SCREEN_HEIGHT = Integer.parseInt(
-        System.getProperty(LwjglProperties.SCREEN_HEIGHT, "1080"));
+        System.getProperty(LwjglProperties.SCREEN_HEIGHT, "600"));
     public static final int REFRESH_RATE = Integer.parseInt(
         System.getProperty(LwjglProperties.REFRESH_RATE, "100"));
     public static final int BITS_PER_PIXEL = Integer.parseInt(
@@ -27,6 +29,10 @@ public class LwjglConfig {
     public static final int JNI_VERSION = Integer.parseInt(
         System.getProperty(LwjglProperties.JNI_VERSION, "24"));
     public static final int UNIFORM_OFFSET_ALIGNMENT = Integer.parseInt(
-        System.getProperty(LwjglProperties.UNIFORM_OFFSET_ALIGNMENT, "1"));
+        System.getProperty(LwjglProperties.UNIFORM_OFFSET_ALIGNMENT, "4"));
+    public static final int MAX_DRAW_BUFFERS = Integer.parseInt(
+        System.getProperty(LwjglProperties.MAX_DRAW_BUFFERS, "8"));
+    public static final int MAX_TEXTURE_SIZE = Integer.parseInt(
+        System.getProperty(LwjglProperties.MAX_TEXTURE_SIZE, "16384"));
 
 }

--- a/headlessmc-lwjgl/src/main/java/io/github/headlesshq/headlessmc/lwjgl/redirections/LwjglRedirections.java
+++ b/headlessmc-lwjgl/src/main/java/io/github/headlesshq/headlessmc/lwjgl/redirections/LwjglRedirections.java
@@ -294,14 +294,7 @@ public class LwjglRedirections {
         // DynamicUniformStorage.<init>
         // GlDevice this.uniformOffsetAlignment = GL11.glGetInteger(35380);
         // division by zero, because the integer returned is 0
-        manager.redirect("Lorg/lwjgl/opengl/GL11;glGetInteger(I)I",
-                (obj, desc, type, args) -> {
-                    if ((int) args[0] == LwjglConfig.GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT) {
-                        return LwjglConfig.UNIFORM_OFFSET_ALIGNMENT;
-                    }
-
-                    return 0;
-                });
+        manager.redirect("Lorg/lwjgl/opengl/GL11;glGetInteger(I)I", LwjglRedirections::glGetInteger);
 
         // Forge 1.21.10
         //java.lang.IllegalArgumentException: mipLevels must be at least 1
@@ -310,6 +303,55 @@ public class LwjglRedirections {
                 (obj, desc, type, args) -> 1);
 
         ByteBufferRedirections.redirect(manager);
+
+        // 26.2 com.mojang.blaze3d.platform.NativeLibrariesBootstrap is now very annoying
+        manager.redirect("Lorg/lwjgl/stb/STBImage;stbi_failure_reason()Ljava/lang/String;",
+                         (obj, desc, type, args) -> null);
+
+        // 26.2 introduces GPUDevice.getDeviceInfo.limits:
+        // on my laptop this reports:
+        // DeviceLimits[maxAnisotropy=16, minUniformOffsetAlignment=4, maxTextureSize=16384, maxMemoryAllocationSize=Long.MAX_VALUE, maxMultiDrawDirectInterleavedDrawCount=0, maxColorAttachments=8]
+        // TODO: maxAnisotropy
+        // TODO: maxTextureSize=16384
+
+        // 26.2 onwards
+        // DynamicUniformStorage.<init>
+        // For GPUDevice DeviceLimits
+        // division by zero, because the integer returned is 0
+        manager.redirect("Lorg/lwjgl/opengl/GL11C;glGetInteger(I)I", LwjglRedirections::glGetInteger);
+
+        manager.redirect("Lorg/lwjgl/vulkan/VkPhysicalDeviceLimits;minUniformBufferOffsetAlignment()J",
+                         (obj, desc, type, args) -> (long) LwjglConfig.UNIFORM_OFFSET_ALIGNMENT
+        );
+
+        manager.redirect("Lorg/lwjgl/vulkan/VkPhysicalDeviceLimits;maxImageDimension2D()I",
+                         (obj, desc, type, args) -> LwjglConfig.MAX_TEXTURE_SIZE
+        );
+
+        manager.redirect("Lorg/lwjgl/vulkan/VkPhysicalDeviceVulkan11Properties;maxMemoryAllocationSize()J",
+                         (obj, desc, type, args) -> Long.MAX_VALUE
+        );
+
+        manager.redirect("Lorg/lwjgl/vulkan/VkPhysicalDeviceLimits;maxColorAttachments()I",
+                         (obj, desc, type, args) -> LwjglConfig.MAX_DRAW_BUFFERS
+        );
+
+        manager.redirect(
+            "Lorg/lwjgl/opengl/GL20C;glCreateProgram()I",
+            (obj, desc, type, args) -> 1
+        );
+    }
+
+    private static int glGetInteger(Object obj, String desc, Class<?> type, Object... args) {
+        if ((int) args[0] == LwjglConfig.GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT) {
+            return LwjglConfig.UNIFORM_OFFSET_ALIGNMENT;
+        } else if ((int) args[0] == LwjglConfig.GL_MAX_DRAW_BUFFERS) {
+            return LwjglConfig.MAX_DRAW_BUFFERS;
+        } else if ((int) args[0] == LwjglConfig.GL_MAX_TEXTURE_SIZE) {
+            return LwjglConfig.MAX_TEXTURE_SIZE;
+        }
+
+        return 0;
     }
 
 }

--- a/headlessmc-lwjgl/src/main/java/io/github/headlesshq/headlessmc/lwjgl/transformer/LwjglTransformer.java
+++ b/headlessmc-lwjgl/src/main/java/io/github/headlesshq/headlessmc/lwjgl/transformer/LwjglTransformer.java
@@ -1,5 +1,6 @@
 package io.github.headlesshq.headlessmc.lwjgl.transformer;
 
+import io.github.headlesshq.headlessmc.lwjgl.LwjglProperties;
 import io.github.headlesshq.headlessmc.lwjgl.api.Redirection;
 import io.github.headlesshq.headlessmc.lwjgl.api.RedirectionApi;
 import io.github.headlesshq.headlessmc.lwjgl.api.Transformer;
@@ -7,8 +8,8 @@ import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.*;
 
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Locale;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.objectweb.asm.Opcodes.*;
 
@@ -27,8 +28,21 @@ import static org.objectweb.asm.Opcodes.*;
  * their body transformed as described above.
  */
 public class LwjglTransformer implements Transformer {
+    public static final String DEFAULT_IGNORED = "org/lwjgl/system/Configuration,org/lwjgl/system/Platform";
+    private static final Set<String> IGNORE_CLASSES = Arrays.stream(
+        System.getProperty(LwjglProperties.IGNORE_CLASSES, DEFAULT_IGNORED).split(","))
+        .filter(string -> !string.trim().isEmpty())
+        .collect(Collectors.toSet());
+    private static final List<String> SUB_CLASSES = IGNORE_CLASSES.stream()
+        .map(string -> string + "$")
+        .collect(Collectors.toList());
+
     @Override
     public void transform(ClassNode cn) {
+        if (cn.name != null && (IGNORE_CLASSES.contains(cn.name) || isIgnoredSubClass(cn.name))) {
+            return;
+        }
+
         try {
             transformModule(cn);
         } catch (NoSuchFieldError ignored) {
@@ -196,4 +210,20 @@ public class LwjglTransformer implements Transformer {
             il.add(new InsnNode(AASTORE));
         }
     }
+
+
+    private boolean isIgnoredSubClass(String className) {
+        if (!className.contains("$")) {
+            return false;
+        }
+
+        for (String subclassPrefix : SUB_CLASSES) {
+            if (className.startsWith(subclassPrefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
 }

--- a/headlessmc-lwjgl/src/test/java/io/github/headlesshq/headlessmc/lwjgl/LwjglInstrumentationTest.java
+++ b/headlessmc-lwjgl/src/test/java/io/github/headlesshq/headlessmc/lwjgl/LwjglInstrumentationTest.java
@@ -103,6 +103,20 @@ public class LwjglInstrumentationTest {
 
     @Test
     @SneakyThrows
+    public void testConfigurationStaticInitializerPreserved() {
+        // org.lwjgl.system.Configuration must be left untouched so its static
+        // option fields keep their values; otherwise Minecraft 26.2's
+        // NativeLibrariesBootstrap NPEs reading SHARED_LIBRARY_EXTRACT_PATH.
+        val configuration = load(org.lwjgl.system.Configuration.class);
+        val field = configuration.getField("SHARED_LIBRARY_EXTRACT_PATH");
+        assertNotNull(
+            field.get(null),
+            "Configuration's static initializer must be preserved so its "
+                + "static option fields are non-null");
+    }
+
+    @Test
+    @SneakyThrows
     public void testArrayReturnValue() {
         val lwjgl = new Lwjgl("test");
         assertNull(lwjgl.returnsByteArray("test"));

--- a/headlessmc-lwjgl/src/test/java/org/lwjgl/system/Configuration.java
+++ b/headlessmc-lwjgl/src/test/java/org/lwjgl/system/Configuration.java
@@ -1,0 +1,21 @@
+package org.lwjgl.system;
+
+/**
+ * Minimal stand-in for {@code org.lwjgl.system.Configuration}, mirroring the
+ * shape the transformer must preserve: a {@code public static final} field
+ * assigned in the static initializer. If the transformer gutted the static
+ * initializer (as it does for every other lwjgl class) this field would be
+ * {@code null} after loading.
+ *
+ * @see LwjglInstrumentationTest#testConfigurationStaticInitializerPreserved()
+ */
+@SuppressWarnings("unused")
+public final class Configuration {
+    public static final Configuration SHARED_LIBRARY_EXTRACT_PATH =
+        new Configuration();
+
+    public Object get() {
+        return null;
+    }
+
+}


### PR DESCRIPTION
Related:
headlesshq/mc-runtime-test#137
headlesshq/mc-runtime-test#138
headlesshq/mc-runtime-test#140

Multiple Fixes to the LWJGL instrumentation as many things changed with 26.2.
Namely DeviceLimits for GPUDevices were introduced and we need to deliver the correct values.