### PR TITLE
fix(lwjgl): preserve org.lwjgl.system.Configuration static initializer

### DIFF
--- a/headlessmc-lwjgl/src/main/java/io/github/headlesshq/headlessmc/lwjgl/transformer/LwjglTransformer.java
+++ b/headlessmc-lwjgl/src/main/java/io/github/headlesshq/headlessmc/lwjgl/transformer/LwjglTransformer.java
@@ -27,8 +27,27 @@ import static org.objectweb.asm.Opcodes.*;
  * their body transformed as described above.
  */
 public class LwjglTransformer implements Transformer {
+    /**
+     * {@code org.lwjgl.system.Configuration} is a pure configuration registry:
+     * its {@code public static final Configuration<?>} option fields are
+     * assigned in the static initializer and it makes no native calls. If we
+     * transform it like every other lwjgl class its static initializer gets
+     * gutted, leaving those fields {@code null}. Minecraft 26.2's {@code
+     * com.mojang.blaze3d.platform.NativeLibrariesBootstrap} reads {@code
+     * Configuration.SHARED_LIBRARY_EXTRACT_PATH} while loading native libraries,
+     * which then throws a {@link NullPointerException} and crashes the game
+     * before it starts. Leaving the class untouched lets it behave exactly as it
+     * does without the agent (i.e. as it already does in a real, non-headless
+     * launch), while every actual native/GL class stays stubbed.
+     */
+    private static final String CONFIGURATION = "org/lwjgl/system/Configuration";
+
     @Override
     public void transform(ClassNode cn) {
+        if (CONFIGURATION.equals(cn.name)) {
+            return;
+        }
+
         try {
             transformModule(cn);
         } catch (NoSuchFieldError ignored) {

--- a/headlessmc-lwjgl/src/test/java/io/github/headlesshq/headlessmc/lwjgl/LwjglInstrumentationTest.java
+++ b/headlessmc-lwjgl/src/test/java/io/github/headlesshq/headlessmc/lwjgl/LwjglInstrumentationTest.java
@@ -186,6 +186,20 @@ public class LwjglInstrumentationTest {
 
     @Test
     @SneakyThrows
+    public void testConfigurationStaticInitializerPreserved() {
+        // org.lwjgl.system.Configuration must be left untouched so its static
+        // option fields keep their values; otherwise Minecraft 26.2's
+        // NativeLibrariesBootstrap NPEs reading SHARED_LIBRARY_EXTRACT_PATH.
+        val configuration = load(org.lwjgl.system.Configuration.class);
+        val field = configuration.getField("SHARED_LIBRARY_EXTRACT_PATH");
+        assertNotNull(
+            field.get(null),
+            "Configuration's static initializer must be preserved so its "
+                + "static option fields are non-null");
+    }
+
+    @Test
+    @SneakyThrows
     public void testLwjglAbstractClass() {
         assertNull(AbstractLwjglClass.factoryMethod("test"));
         assertTrue(Modifier.isAbstract(

--- a/headlessmc-lwjgl/src/test/java/org/lwjgl/system/Configuration.java
+++ b/headlessmc-lwjgl/src/test/java/org/lwjgl/system/Configuration.java
@@ -1,0 +1,22 @@
+package org.lwjgl.system;
+
+import io.github.headlesshq.headlessmc.lwjgl.LwjglInstrumentationTest;
+
+/**
+ * Minimal stand-in for {@code org.lwjgl.system.Configuration}, mirroring the
+ * shape the transformer must preserve: a {@code public static final} field
+ * assigned in the static initializer. If the transformer gutted the static
+ * initializer (as it does for every other lwjgl class) this field would be
+ * {@code null} after loading.
+ *
+ * @see LwjglInstrumentationTest#testConfigurationStaticInitializerPreserved()
+ */
+@SuppressWarnings("unused")
+public final class Configuration {
+    public static final Configuration SHARED_LIBRARY_EXTRACT_PATH =
+        new Configuration();
+
+    public Object get() {
+        return null;
+    }
+}


### PR DESCRIPTION
## Problem

Launching Minecraft **26.2** headlessly with the `--lwjgl` agent crashes on startup (exit 253), for all three modloaders (Fabric, NeoForge, LexForge):

```
Description: Loading native libraries
java.lang.NullPointerException: Cannot invoke "org.lwjgl.system.Configuration.get()"
  because "org.lwjgl.system.Configuration.SHARED_LIBRARY_EXTRACT_PATH" is null
	at com.mojang.blaze3d.platform.NativeLibrariesBootstrap.configureLWJGLLibraryPath(NativeLibrariesBootstrap.java:168)
	at com.mojang.blaze3d.platform.NativeLibrariesBootstrap.loadLibraries(NativeLibrariesBootstrap.java:64)
	at net.minecraft.client.main.Main.main(Main.java:131)
```

## Root cause

`LwjglTransformer` transforms every `org/lwjgl` class by replacing all method bodies with redirection calls, **including the static initializer** (`<clinit>`). For `org.lwjgl.system.Configuration` this means its `public static final Configuration<?>` option fields are never assigned and stay `null`.

Minecraft 26.2 introduced `com.mojang.blaze3d.platform.NativeLibrariesBootstrap`, which reads `Configuration.SHARED_LIBRARY_EXTRACT_PATH` during native-library loading. Because the field is `null`, the client NPEs before the window opens. Earlier versions (26.1.x and below) never touched `Configuration` at bootstrap, so the gutted initializer was harmless — this only surfaces on 26.2+.

## Fix

Leave `org.lwjgl.system.Configuration` untransformed. It is a pure configuration registry with no native calls, so it can safely run as-is. It then behaves exactly as it does in a real (non-headless) launch — where these fields are always populated — while every actual native/GL class stays stubbed.

## Testing

- Added `LwjglInstrumentationTest.testConfigurationStaticInitializerPreserved()`, which loads a stub `org.lwjgl.system.Configuration` through the transformer and asserts its static field is non-null. Verified it **fails without** the guard (`expected: not <null>`) and **passes with** it.
- Full `:headlessmc-lwjgl:test` suite passes.

## Context

Surfaced while adding Minecraft 26.2 support to `headlesshq/mc-runtime-test` (headlesshq/mc-runtime-test#137). The default `xvfb` path already works on 26.2; only the `--lwjgl` headless path hit this. Once released, mc-runtime-test can bump its `hmc-version` to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)