### PR TITLE
fix(server): migrate PaperDownloader to PaperMC v3 (fill) API

### DIFF
--- a/headlessmc-launcher/src/main/java/io/github/headlesshq/headlessmc/launcher/server/downloader/PaperDownloader.java
+++ b/headlessmc-launcher/src/main/java/io/github/headlesshq/headlessmc/launcher/server/downloader/PaperDownloader.java
@@ -2,6 +2,7 @@ package io.github.headlesshq.headlessmc.launcher.server.downloader;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
@@ -19,34 +20,50 @@ import java.net.URL;
 @CustomLog
 @RequiredArgsConstructor
 public class PaperDownloader implements ServerTypeDownloader {
-    private static final URL URL = URLs.url("https://api.papermc.io/v2/projects/paper/versions/");
+    // PaperMC's v2 API (api.papermc.io/v2) was sunset and now returns HTTP 410.
+    // The current API is v3 ("fill"), which returns builds newest-first and
+    // provides a ready-made download url per build.
+    private static final URL URL = URLs.url("https://fill.papermc.io/v3/projects/paper/versions/");
 
     @Override
     public DownloadHandler download(Launcher launcher, String version, @Nullable String typeVersionIn, String... args) throws IOException {
-        String build = getBuild(launcher.getDownloadService(), version, typeVersionIn);
-        URL url = new URL(String.format("%s%s/builds/%s/downloads/paper-%s-%s.jar",
-                URL, version, build, version, build));
+        JsonObject build = getBuild(launcher.getDownloadService(), version, typeVersionIn);
+        String buildId = String.valueOf(JsonUtil.getLong(build, "id"));
+        String url = JsonUtil.getString(build, "downloads", "server:default", "url");
+        if (url == null) {
+            throw new IOException("No server download for paper " + version + " build " + buildId);
+        }
+
         log.debug("Downloading paper from " + url);
-        return new UrlJarDownloadHandler(launcher.getDownloadService(), url.toString(), build);
+        return new UrlJarDownloadHandler(launcher.getDownloadService(), url, buildId);
     }
 
-    private String getBuild(DownloadService downloadService, String version, @Nullable String typeVersionIn) throws IOException {
-        String build = typeVersionIn;
-        if (build == null) {
-            HttpResponse response = downloadService.download(new URL(URL + version + "/"));
-            String string = response.getContentAsString();
-            JsonElement element = JsonParser.parseString(string);
-            JsonArray array = JsonUtil.getArray(element, "builds");
-            if (array != null) {
-                build = String.valueOf(array.get(array.size() - 1).getAsInt());
-            }
+    private JsonObject getBuild(DownloadService downloadService, String version, @Nullable String typeVersionIn) throws IOException {
+        HttpResponse response = downloadService.download(new URL(URL + version + "/builds"));
+        String string = response.getContentAsString();
+        JsonElement element = JsonParser.parseString(string);
+        if (!element.isJsonArray()) {
+            throw new IOException("Expected a builds array in " + string);
+        }
 
-            if (build == null) {
-                throw new IOException("No builds found in " + string);
+        JsonArray builds = element.getAsJsonArray();
+        if (builds.isEmpty()) {
+            throw new IOException("No builds found in " + string);
+        }
+
+        // v3 returns builds newest-first, so the latest build is the first entry.
+        if (typeVersionIn == null) {
+            return builds.get(0).getAsJsonObject();
+        }
+
+        for (JsonElement candidate : builds) {
+            JsonObject build = candidate.getAsJsonObject();
+            if (typeVersionIn.equals(String.valueOf(JsonUtil.getLong(build, "id")))) {
+                return build;
             }
         }
 
-        return build;
+        throw new IOException("No paper build " + typeVersionIn + " found for " + version);
     }
 
 }


### PR DESCRIPTION
## Problem

PaperMC sunset the **v2** API (`api.papermc.io/v2`); it now returns **HTTP 410**. `PaperDownloader` still calls it, so `server add paper <version>` fails, breaking `runServerIntegrationTest` (in the `build` job) and the `server-test` jobs on every branch and PR:

```
java.io.IOException: Failed to get https://api.papermc.io/v2/projects/paper/versions/1.21/, response 410:
  {"ok":false,"error":"sunset","message":"This API version has been sunset ..."}
    at ...PaperDownloader.getBuild(PaperDownloader.java:36)
```

(Purpur, on a different API, still downloads fine in the same test — it's specifically Paper's v2 endpoint that's dead.)

## Fix

Switch to PaperMC's current **v3 "fill"** API (`fill.papermc.io/v3`). Two shape changes vs v2:

1. `GET /v3/projects/paper/versions/{version}/builds` returns a **top-level array** ordered **newest-first** (v2 returned `{ "builds": [...] }` oldest-first). So the latest build is `builds[0]`, not the last element.
2. Each build carries a ready-made download URL at `downloads."server:default".url`, so the jar URL no longer needs to be templated.

## Verification

- `:headlessmc-launcher:compileJava` passes.
- Verified against the live API that both code paths resolve correctly: the latest-build path (`builds[0]`) and an explicit-build lookup both yield a valid `server:default` URL that serves a real `application/java-archive` (HTTP 200). v2 confirmed returning 410.
- End-to-end coverage is the existing `runServerIntegrationTest` (`server add paper`), which this unblocks.

## Context

Surfaced while getting Minecraft 26.2 support green (headlesshq/mc-runtime-test#137, #426). This server-side failure is independent of the 26.2 lwjgl work but was reddening the `build` check on those PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)