### PR TITLE
fix(server): migrate PaperDownloader to PaperMC v3 (fill) API

### DIFF
--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -378,7 +378,7 @@ jobs:
         # rename because mc-runtime-test matches a jar with headlessmc-launcher-<version>.jar
         run: cp headlessmc-launcher-wrapper.jar headlessmc-launcher-0.0.0.jar
       - name: Run the MC client
-        uses: headlesshq/mc-runtime-test@4.1.0
+        uses: headlesshq/mc-runtime-test@4.4.0
         with:
           mc: ${{ matrix.version.mc }}
           modloader: ${{ matrix.version.modloader }}
@@ -463,7 +463,7 @@ jobs:
         # rename because mc-runtime-test matches a jar with headlessmc-launcher-<version>.jar
         run: cp headlessmc-launcher-wrapper.jar headlessmc-launcher-0.0.0.jar
       - name: Run the MC client
-        uses: headlesshq/mc-runtime-test@4.1.0
+        uses: headlesshq/mc-runtime-test@4.4.0
         with:
           mc: ${{ matrix.version.mc }}
           modloader: ${{ matrix.version.modloader }}
@@ -533,7 +533,7 @@ jobs:
         run: cp headlessmc-launcher-wrapper.jar headlessmc-launcher-0.0.0.jar
 
       - name: Run the MC client
-        uses: headlesshq/mc-runtime-test@4.1.0
+        uses: headlesshq/mc-runtime-test@4.4.0
         with:
           mc: ${{ matrix.version.mc }}
           modloader: ${{ matrix.version.modloader }}

--- a/.github/workflows/run-matrix-in-memory.yml
+++ b/.github/workflows/run-matrix-in-memory.yml
@@ -110,7 +110,7 @@ jobs:
         # rename because mc-runtime-test matches a jar with headlessmc-launcher-<version>.jar
         run: cp launcher-jar/headlessmc-launcher.jar headlessmc-launcher-0.0.0.jar
       - name: Run the MC client
-        uses: headlesshq/mc-runtime-test@4.1.0
+        uses: headlesshq/mc-runtime-test@4.4.0
         with:
           mc: ${{ matrix.version.mc }}
           modloader: ${{ matrix.version.modloader }}

--- a/docs/dev-ci-cd.md
+++ b/docs/dev-ci-cd.md
@@ -40,7 +40,7 @@ jobs:
           cp build/libs/&lt;your-mod&gt;.jar run/mods
 
       - name: Run MC test client
-        uses: headlesshq/mc-runtime-test@4.1.0
+        uses: headlesshq/mc-runtime-test@4.4.0
         with:
           mc: 1.21.4
           modloader: fabric

--- a/headlessmc-launcher/src/main/java/io/github/headlesshq/headlessmc/launcher/server/downloader/PaperDownloader.java
+++ b/headlessmc-launcher/src/main/java/io/github/headlesshq/headlessmc/launcher/server/downloader/PaperDownloader.java
@@ -2,6 +2,7 @@ package io.github.headlesshq.headlessmc.launcher.server.downloader;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
@@ -19,34 +20,50 @@ import java.net.URL;
 @CustomLog
 @RequiredArgsConstructor
 public class PaperDownloader implements ServerTypeDownloader {
-    private static final URL URL = URLs.url("https://api.papermc.io/v2/projects/paper/versions/");
+    // PaperMC's v2 API (api.papermc.io/v2) was sunset and now returns HTTP 410.
+    // The current API is v3 ("fill"), which returns builds newest-first and
+    // provides a ready-made download url per build.
+    private static final URL URL = URLs.url("https://fill.papermc.io/v3/projects/paper/versions/");
 
     @Override
     public DownloadHandler download(Launcher launcher, String version, @Nullable String typeVersionIn, String... args) throws IOException {
-        String build = getBuild(launcher.getDownloadService(), version, typeVersionIn);
-        URL url = new URL(String.format("%s%s/builds/%s/downloads/paper-%s-%s.jar",
-                URL, version, build, version, build));
+        JsonObject build = getBuild(launcher.getDownloadService(), version, typeVersionIn);
+        String buildId = String.valueOf(JsonUtil.getLong(build, "id"));
+        String url = JsonUtil.getString(build, "downloads", "server:default", "url");
+        if (url == null) {
+            throw new IOException("No server download for paper " + version + " build " + buildId);
+        }
+
         log.debug("Downloading paper from " + url);
-        return new UrlJarDownloadHandler(launcher.getDownloadService(), url.toString(), build);
+        return new UrlJarDownloadHandler(launcher.getDownloadService(), url, buildId);
     }
 
-    private String getBuild(DownloadService downloadService, String version, @Nullable String typeVersionIn) throws IOException {
-        String build = typeVersionIn;
-        if (build == null) {
-            HttpResponse response = downloadService.download(new URL(URL + version + "/"));
-            String string = response.getContentAsString();
-            JsonElement element = JsonParser.parseString(string);
-            JsonArray array = JsonUtil.getArray(element, "builds");
-            if (array != null) {
-                build = String.valueOf(array.get(array.size() - 1).getAsInt());
-            }
+    private JsonObject getBuild(DownloadService downloadService, String version, @Nullable String typeVersionIn) throws IOException {
+        HttpResponse response = downloadService.download(new URL(URL + version + "/builds"));
+        String string = response.getContentAsString();
+        JsonElement element = JsonParser.parseString(string);
+        if (!element.isJsonArray()) {
+            throw new IOException("Expected a builds array in " + string);
+        }
 
-            if (build == null) {
-                throw new IOException("No builds found in " + string);
+        JsonArray builds = element.getAsJsonArray();
+        if (builds.isEmpty()) {
+            throw new IOException("No builds found in " + string);
+        }
+
+        // v3 returns builds newest-first, so the latest build is the first entry.
+        if (typeVersionIn == null) {
+            return builds.get(0).getAsJsonObject();
+        }
+
+        for (JsonElement candidate : builds) {
+            JsonObject build = candidate.getAsJsonObject();
+            if (typeVersionIn.equals(String.valueOf(JsonUtil.getLong(build, "id")))) {
+                return build;
             }
         }
 
-        return build;
+        throw new IOException("No paper build " + typeVersionIn + " found for " + version);
     }
 
 }


### PR DESCRIPTION
PaperMC sunset the v2 API (api.papermc.io/v2); it now returns HTTP 410, so `server add paper <version>` fails and the server integration test (runServerIntegrationTest) and server-test jobs break on every branch:

    java.io.IOException: Failed to get
      https://api.papermc.io/v2/projects/paper/versions/1.21/, response 410:
      {"ok":false,"error":"sunset", ...}

Switch to the current v3 "fill" API (fill.papermc.io/v3). Two shape changes versus v2: the builds endpoint returns a top-level array ordered newest-first (v2 was an object with a builds array, oldest-first), and each build carries a ready-made download url under downloads."server:default".url, so the jar URL no longer needs to be templated. Verified against the live API: the latest-build path and an explicit-build lookup both resolve to a valid server jar.